### PR TITLE
Fixed 'network lock not available' error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG VERSION="expressvpn_${NUM}-1_${PLATFORM}.deb"
 COPY files/ /expressvpn/
 
 RUN apt update && apt install -y --no-install-recommends \
-    expect curl ca-certificates iproute2 wget jq \
+    expect curl ca-certificates iproute2 wget jq iptables \
     && wget -q https://www.expressvpn.works/clients/linux/${VERSION} -O /expressvpn/${VERSION} \
     && dpkg -i /expressvpn/${VERSION} \
     && rm -rf /expressvpn/*.deb \


### PR DESCRIPTION
Fixes #3 

`expressvpn preferences set network_lock on` requires `iptables` to function.

Tested locally and validated by comparing the output from `iptables -L` with `network_lock` set to `on` vs `off`.