### PR TITLE
Misioslav/issue55

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ services:
     privileged: true
 ```
 
+> **Note:** `start.sh` now begins the supervision loop before honoring an overridden `command`, so any custom wrappers (DNS sync, routing scripts, etc.) can still run while the loop keeps reconnecting the VPN and exposing health failures when the tunnel stays down.
+
 ## Configuration
 
 Environment variables (defaults shown):
@@ -124,6 +126,7 @@ Environment variables (defaults shown):
 | SERVER | Region name or `smart` | smart |
 | PROTOCOL | VPN protocol | lightwayudp |
 | CONNECTION_CHECK_INTERVAL | Seconds between supervision loop checks | 30 |
+| RECONNECT_FAILURE_THRESHOLD | Consecutive reconnect failures before marking unhealthy | 3 |
 | NETWORK | Network Lock (`on`/`off`) | on |
 | ALLOW_LAN | Allow LAN access while Network Lock is on | true |
 | LAN_CIDR | Comma-separated LAN CIDRs for return routes | (empty) |
@@ -148,6 +151,13 @@ Environment variables (defaults shown):
 | SOCKS_WHITELIST | Comma-separated IPs bypassing auth | (empty) |
 | SOCKS_AUTH_ONCE | Cache auth by IP (`true`/`false`) | false |
 | SOCKS_LOGS | Enable microsocks logs (`true`/`false`) | true |
+
+### Supervision failure flag
+
+The supervision loop writes `/tmp/expressvpn/reconnect-failure.flag` when
+`RECONNECT_FAILURE_THRESHOLD` consecutive reconnect attempts fail. The
+built-in healthcheck reads that flag and reports `/fail`, which makes Docker
+mark the container as unhealthy until the VPN reconnects and clears the flag.
 
 ## Protocols
 

--- a/files/healthcheck.sh
+++ b/files/healthcheck.sh
@@ -32,6 +32,12 @@ notify_healthcheck() {
 }
 
 main() {
+    local failure_flag="/tmp/expressvpn/reconnect-failure.flag"
+    if [[ -f "${failure_flag}" ]]; then
+        notify_healthcheck "/fail" || true
+        exit 1
+    fi
+
     local target_ip
     target_ip=$(resolve_check_ip || true)
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -354,18 +354,65 @@ wait_for_connection() {
 supervise_connection_loop() {
     local interval="${CONNECTION_CHECK_INTERVAL:-30}"
     local target="${SERVER:-smart}"
+    local failure_threshold="${RECONNECT_FAILURE_THRESHOLD:-3}"
+    local failure_flag="/tmp/expressvpn/reconnect-failure.flag"
+    local failure_count=0
+    mkdir -p "$(dirname "${failure_flag}")"
+
+    clear_failure_flag() {
+        if [[ -f "${failure_flag}" ]]; then
+            rm -f "${failure_flag}"
+            log "Cleared persistent failure flag at ${failure_flag}."
+        fi
+    }
+
+    mark_failure_flag() {
+        if [[ ! -f "${failure_flag}" ]]; then
+            touch "${failure_flag}"
+            log "Marked failure flag at ${failure_flag}; healthcheck will report unhealthy."
+        fi
+    }
+
     log "Entering supervision loop (interval ${interval}s) to keep ${target} connected."
     while true; do
         if ! check_connected || [[ ! -d /sys/class/net/tun0 ]]; then
             log "VPN down (missing tun0 or not connected). Attempting reconnect to ${target}..."
             if expressvpnctl connect "${target}" >/dev/null 2>&1; then
                 wait_for_connection
+                failure_count=0
+                clear_failure_flag
             else
                 log "Reconnection attempt to ${target} failed. Will retry in ${interval}s."
+                failure_count=$((failure_count + 1))
+                if [[ "${failure_threshold}" -gt 0 && "${failure_count}" -ge "${failure_threshold}" ]]; then
+                    log "Exceeded ${failure_threshold} consecutive reconnect failures; flagging unhealthy."
+                    mark_failure_flag
+                fi
             fi
+        else
+            failure_count=0
+            clear_failure_flag
         fi
         sleep "${interval}"
     done
+}
+
+supervisor_pid=""
+
+start_supervisor() {
+    supervise_connection_loop &
+    supervisor_pid=$!
+    log "Started supervision loop (PID ${supervisor_pid})."
+}
+
+stop_supervisor() {
+    if [[ -z "${supervisor_pid:-}" ]]; then
+        return
+    fi
+    log "Stopping supervision loop (PID ${supervisor_pid})."
+    kill "${supervisor_pid}" 2>/dev/null || true
+    wait "${supervisor_pid}" 2>/dev/null || true
+    supervisor_pid=""
 }
 
 main() {
@@ -382,11 +429,18 @@ main() {
     start_socks_proxy
     start_control_server
 
+    start_supervisor
+    trap 'stop_supervisor' EXIT
+
     if [[ $# -gt 0 ]]; then
-        exec "$@"
+        "$@"
+        exit_code=$?
+        stop_supervisor
+        exit "$exit_code"
     fi
 
-    supervise_connection_loop & wait "$!"
+    wait "${supervisor_pid}"
+    stop_supervisor
 }
 
 main "$@"


### PR DESCRIPTION
Introduces a background supervision loop that:

- Automatically monitors and reconnects the VPN (every 30s by default)
- Tracks consecutive reconnection failures
- Marks container unhealthy via healthcheck after threshold failures
- Integrates gracefully with custom commands

New Environment Variables

- **CONNECTION_CHECK_INTERVAL** (default: 30s) - Check frequency
- **RECONNECT_FAILURE_THRESHOLD** (default: 3) - Failures before unhealthy

Key Changes

- Added supervise_connection_loop() for automatic reconnection
- Enhanced healthcheck to detect /tmp/expressvpn/reconnect-failure.flag
- Supervisor starts before custom commands and cleans up on exit
- Updated README with new configuration options

The container now actively maintains VPN connectivity throughout its lifetime instead of passively waiting for disconnection.