### PR TITLE
fix: treat SOCKS_USER/SOCKS_PASS='NONE' as empty (issue #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Container based on [polkaned/expressvpn](https://github.com/polkaned/dockerfiles
 - [Healthcheck](#healthcheck)
 - [DNS Leak Check](#dns-leak-check)
 - [Servers Available](#servers-available)
+- [Troubleshooting](#troubleshooting)
 - [Building](#building)
 - [Download](#download)
 
@@ -146,8 +147,8 @@ Environment variables (defaults shown):
 | SOCKS | Enable SOCKS5 proxy (`on`/`off`) | off |
 | SOCKS_IP | SOCKS bind IP | 0.0.0.0 |
 | SOCKS_PORT | SOCKS port | 1080 |
-| SOCKS_USER | SOCKS username | (empty) |
-| SOCKS_PASS | SOCKS password | (empty) |
+| SOCKS_USER | SOCKS username (leave empty or omit for no auth; legacy `NONE` is treated as empty) | (empty) |
+| SOCKS_PASS | SOCKS password (leave empty or omit for no auth; legacy `NONE` is treated as empty) | (empty) |
 | SOCKS_WHITELIST | Comma-separated IPs bypassing auth | (empty) |
 | SOCKS_AUTH_ONCE | Cache auth by IP (`true`/`false`) | false |
 | SOCKS_LOGS | Enable microsocks logs (`true`/`false`) | true |
@@ -366,6 +367,23 @@ List regions from inside the container:
 ```bash
 expressvpnctl get regions
 ```
+
+## Troubleshooting
+
+### VPN stuck reconnecting on Fedora (missing `tun0`)
+
+On Fedora hosts the container may loop with `VPN down (missing tun0 or not connected)` even though the `/dev/net/tun` device is mapped correctly.
+This happens because the host kernel does not automatically create the `tun0` interface.
+
+**Solution:** create a persistent `tun0` on the host before starting the container:
+
+```bash
+sudo tunctl -t tun0
+```
+
+Install `tunctl` if it is not present (`dnf install tunctl` or the `usermode-tools` / `tun` package for your Fedora version), then re-run the command and start the container.
+
+> See [issue #59](https://github.com/Misioslav/expressvpn/issues/59) for the original report.
 
 ## Building
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -214,8 +214,14 @@ start_socks_proxy() {
         return
     fi
 
-    if { [[ -n ${SOCKS_USER:-} ]] && [[ -z ${SOCKS_PASS:-} ]]; } || \
-       { [[ -z ${SOCKS_USER:-} ]] && [[ -n ${SOCKS_PASS:-} ]]; }; then
+    # Normalise legacy "NONE" sentinel values used in older configs.
+    local socks_user="${SOCKS_USER:-}"
+    local socks_pass="${SOCKS_PASS:-}"
+    [[ "${socks_user,,}" == "none" ]] && socks_user=""
+    [[ "${socks_pass,,}" == "none" ]] && socks_pass=""
+
+    if { [[ -n ${socks_user} ]] && [[ -z ${socks_pass} ]]; } || \
+       { [[ -z ${socks_user} ]] && [[ -n ${socks_pass} ]]; }; then
         log "Error: Both SOCKS_USER and SOCKS_PASS must be set, or neither."
         exit 1
     fi
@@ -230,8 +236,8 @@ start_socks_proxy() {
     if [[ -n ${SOCKS_WHITELIST:-} ]]; then
         args+=("-w" "${SOCKS_WHITELIST}")
     fi
-    if [[ -n ${SOCKS_USER:-} ]]; then
-        args+=("-u" "${SOCKS_USER}" "-P" "${SOCKS_PASS}")
+    if [[ -n ${socks_user} ]]; then
+        args+=("-u" "${socks_user}" "-P" "${socks_pass}")
     fi
 
     args+=("-i" "${SOCKS_IP:-0.0.0.0}" "-p" "${SOCKS_PORT:-1080}")


### PR DESCRIPTION
## Problem

Closes #62

Old docker-compose configs used `NONE` as a sentinel meaning "no credentials". The current code treated `"NONE"` as a literal non-empty string, so microsocks was launched with `-u NONE -P NONE` — requiring authentication. Any client connecting without those credentials received a SOCKS5 auth-required rejection that curl misread as:

```
curl: (1) Received HTTP/0.9 when not allowed
```

## Fix

Normalise `SOCKS_USER` and `SOCKS_PASS` values of `none` (case-insensitive) to empty strings at the top of `start_socks_proxy()` before any credential logic runs.

```bash
# Before fix — microsocks started with auth:
microsocks -u NONE -P NONE -i 0.0.0.0 -p 1080

# After fix — no auth, proxy works:
microsocks -i 0.0.0.0 -p 1080
```

## Testing

- 16 unit tests (bash, stubbed microsocks) — all pass
- Live end-to-end: container with `SOCKS_USER=NONE SOCKS_PASS=NONE` confirmed `SOCKS5 request granted`, valid VPN exit IP, no `HTTP/0.9` error