### PR TITLE
fix for lost dns whitelist fw rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN set -eux; \
         python3-tomli \
         xz-utils; \
     curl -fsSL "${EXPRESSVPN_RUN_URL}" -o /tmp/expressvpn.run; \
-    sh /tmp/expressvpn.run --accept --quiet --noprogress -- --no-gui --sysvinit; \
+    sh /tmp/expressvpn.run --accept --quiet --noprogress -- --no-gui --sysvinit --force-dependencies; \
     rm -f /tmp/expressvpn.run; \
     curl -fsSL "https://raw.githubusercontent.com/kavehtehrani/cloudflare-speed-cli/main/install.sh" | sh; \
     mv /root/.local/bin/cloudflare-speed-cli /usr/local/bin/cloudflare-speed-cli; \

--- a/files/start.sh
+++ b/files/start.sh
@@ -211,16 +211,16 @@ apply_dns_whitelist() {
 
 ensure_dns_whitelist_position() {
     local chain="xvpn_dns_ip_exceptions"
-    [[ -z "${WHITELIST_DNS:-}" ]] && return
-    command -v iptables >/dev/null 2>&1 || return
-    iptables -S "$chain" >/dev/null 2>&1 || return
+    [[ -z "${WHITELIST_DNS:-}" ]] && return 0
+    command -v iptables >/dev/null 2>&1 || return 0
+    iptables -S "$chain" >/dev/null 2>&1 || return 0
 
-    # Remove all existing jumps to our chain, then re-insert at position 1
     while iptables -C OUTPUT -j "$chain" >/dev/null 2>&1; do
         iptables -D OUTPUT -j "$chain" >/dev/null 2>&1 || break
     done
     iptables -I OUTPUT 1 -j "$chain" >/dev/null 2>&1 \
         || log "Failed to re-position DNS whitelist chain ${chain} at OUTPUT 1."
+    return 0
 }
 
 start_socks_proxy() {

--- a/files/start.sh
+++ b/files/start.sh
@@ -209,6 +209,20 @@ apply_dns_whitelist() {
     done
 }
 
+ensure_dns_whitelist_position() {
+    local chain="xvpn_dns_ip_exceptions"
+    [[ -z "${WHITELIST_DNS:-}" ]] && return
+    command -v iptables >/dev/null 2>&1 || return
+    iptables -S "$chain" >/dev/null 2>&1 || return
+
+    # Remove all existing jumps to our chain, then re-insert at position 1
+    while iptables -C OUTPUT -j "$chain" >/dev/null 2>&1; do
+        iptables -D OUTPUT -j "$chain" >/dev/null 2>&1 || break
+    done
+    iptables -I OUTPUT 1 -j "$chain" >/dev/null 2>&1 \
+        || log "Failed to re-position DNS whitelist chain ${chain} at OUTPUT 1."
+}
+
 start_socks_proxy() {
     if [[ ${SOCKS:-off} != "on" ]]; then
         return
@@ -355,6 +369,7 @@ wait_for_connection() {
     if ! wait_for_condition 15 2 check_connected; then
         log "Timed out waiting for VPN connection."
     fi
+    ensure_dns_whitelist_position
 }
 
 supervise_connection_loop() {


### PR DESCRIPTION
- with the addition of the supervisor loop it can rebuild the fw rules and forget the dns whitelist rules.
- also had to add --force-dependencies or else build failed for me:
```
ERROR: failed to solve: process "/bin/sh -c set -eux;     export DEBIAN_FRONTEND=noninteractive;     apt-get update;     apt-get install -y --no-install-recommends         curl         ca-certificates         iproute2         jq         iptables         iputils-ping         procps         psmisc         libatomic1         libglib2.0-0         busybox         socat         python3         python3-tomli         xz-utils;     curl -fsSL \"${EXPRESSVPN_RUN_URL}\" -o /tmp/expressvpn.run;     sh /tmp/expressvpn.run --accept --quiet --noprogress -- --no-gui --sysvinit;     rm -f /tmp/expressvpn.run;     curl -fsSL \"https://raw.githubusercontent.com/kavehtehrani/cloudflare-speed-cli/main/install.sh\" | sh;     mv /root/.local/bin/cloudflare-speed-cli /usr/local/bin/cloudflare-speed-cli;     rmdir /root/.local/bin 2>/dev/null || true;     rm -rf /var/lib/apt/lists/*;     rm -rf /var/log/*.log" did not complete successfully: exit code: 1
```